### PR TITLE
ビルドエラーの修正対応

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-apache
+FROM php:7.0-apache
 COPY php.ini /usr/local/etc/php/
 RUN apt-get update \
   && apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libpng12-dev libmcrypt-dev \


### PR DESCRIPTION
以下のQiitaの記事を参照してdockerを立ち上げようとしたのですが
https://qiita.com/naga3/items/d1a6e8bbd0799159042e

ビルドの際に以下のようなエラーが出ました
```
docker-compose up -d

省略
E: Package 'libpng12-dev' has no installation candidate
ERROR: Service 'php' failed to build: The command '/bin/sh -c apt-get update   && apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libpng12-dev libmcrypt-dev   && docker-php-ext-install pdo_mysql mysqli mbstring gd iconv mcrypt' returned a non-zero code: 100

```
以下の記事を参照にビルドのエラーを解消しました

https://github.com/deskpro/deskpro-docker/issues/1


一度イメージを削除してupコマンドを叩くとエラー再現できると思います
```
docker images -aq | xargs docker rmi
docker-compose up -d
```

以上、お手数ですがご確認のほどお願いします。

参考
https://qiita.com/fist0/items/2fb1c7f894b5bdff79f4

